### PR TITLE
fix: Ruby 3 compatibility for network configuration

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1241,8 +1241,8 @@ describe Kitchen::Driver::Vagrant do
       cmd
 
       expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {6}/, "").chomp))
-        c.vm.network(:forwarded_port, {:guest=>80, :host=>8080})
-        c.vm.network(:private_network, {:ip=>"192.168.33.33"})
+        c.vm.network(:forwarded_port, :guest=>80, :host=>8080)
+        c.vm.network(:private_network, :ip=>"192.168.33.33")
       RUBY
     end
 

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -81,7 +81,7 @@ Vagrant.configure("2") do |c|
 <% end %>
 
 <% Array(config[:network]).each do |opts| %>
-  c.vm.network(:<%= opts[0] %>, <%= opts[1..-1].join(", ") %>)
+  c.vm.network(:<%= opts[0] %>, <%= opts[1].to_s.delete_prefix('{').delete_suffix('}') %>)
 <% end %>
 
   c.vm.synced_folder ".", "/vagrant", disabled: true


### PR DESCRIPTION
The final Vagrant file should be compatible with Ruby 2.7 and 3,
so it should look like that:

```diff
- c.vm.network(:forwarded_port, {:guest=>443, :host=>2443})
+ c.vm.network(:forwarded_port, :guest=>443, :host=>2443)
```

Fixes #476